### PR TITLE
Fix sharing a product page on Android not sending the URL

### DIFF
--- a/app/scenes/postPage.js
+++ b/app/scenes/postPage.js
@@ -10,7 +10,8 @@ import {
     Dimensions,
     TouchableOpacity,
     AsyncStorage,
-    ToastAndroid
+    ToastAndroid,
+    Platform
 } from 'react-native';
 import {HOST} from "../constants";
 let {height, width} = Dimensions.get('window');
@@ -81,13 +82,13 @@ class Screen extends Component {
         this.props.navigation.dispatch(navigateAction);
     }
 
-
     sharePost(post) {
+        let sharedMessage = Platform.OS === "ios" ? post.tagline : post.tagline + "\n" + post.discussion_url;
         Share.share({
             dialogTitle: 'Sharing is Caring',
             title: post.name,
-            message: post.tagline,
-            url: post.redirect_url,
+            message: sharedMessage,
+            url: post.discussion_url,
         });
     }
 


### PR DESCRIPTION
This fixes #7 
On Android the URL of the product page was not copied in the message.
Also the URL was retrieved from a wrong JSON property.